### PR TITLE
Fix pixel errors and resource name

### DIFF
--- a/net/buildism/mhk/MohawkExtractor/MohawkExtractor.java
+++ b/net/buildism/mhk/MohawkExtractor/MohawkExtractor.java
@@ -87,11 +87,11 @@ public class MohawkExtractor {
         int resourceIndexInFileTable = ushort(bb.getShort());
         bb.mark();
         bb.position(resourceDirOffset + resourceNameListOffset + nameListOffset);
-        byte ch = -1;
+        byte ch = bb.get();
         String name = "";
         while(ch != 0) {
-          ch = bb.get();
           name += Character.toString((char) ch);
+          ch = bb.get();
         }
         bb.reset();
         int resourceId = typeInfo.resourceIndexToResourceId.get(resourceIndexInFileTable);

--- a/net/buildism/mhk/MohawkExtractor/MohawkExtractor.java
+++ b/net/buildism/mhk/MohawkExtractor/MohawkExtractor.java
@@ -461,9 +461,6 @@ public class MohawkExtractor {
             for (int y = 0; y < height; y++) {
               for (int x = 0; x < bytesPerRow; x++) {
                 int colorIndex = image[i];
-                if (colorIndex < 0) {
-                  colorIndex = 255;
-                }
                 Color color = colors[colorIndex & 0xff];
                 if (x < width) output.setRGB(x, y, color.getRGB());
                 i++;


### PR DESCRIPTION
I've compared the extracted images with images extracted with another program and with the game, and many images have pixel differences. The differences occur mostly in dark areas and are not obvious. They are caused by setting negative color index values to 255 instead of taking the modulo with 255.

This PR corrects that error by simply removing the code thats set the value to 255; the `colorIndex & 0xff` that occurs directly afterwards correctly handles negative index values.

In addition, a trailing null character in the resource name is corrected.